### PR TITLE
fix: improve Windows path handling and directory navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install this plugin using your favorite plugin manager:
 
 ### Using [vim-plug](https://github.com/junegunn/vim-plug):
 
-    Plug 'yourusername/vim-file-manager'
+    Plug 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -43,7 +43,7 @@ Then run:
 
 ### Using [Vundle](https://github.com/VundleVim/Vundle.vim):
 
-    Plugin 'yourusername/vim-file-manager'
+    Plugin 'mahadevan-k/vimnc'
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@ A simple and intuitive file manager plugin for Vim that allows you to navigate a
 
 ## Keybindings
 
-| Key      | Action                  |
-|----------|-------------------------|
-| `h`      | Go to parent folder |
-| `l`      | Go into folder |
-| `j`      | Move down the list |
-| `k`      | Move up the list |
-| `Enter`  | Open file/folder               |
-| `Space`  | Select / unselect files/folders |
-| `x`      | Cut selected items      |
-| `y`      | Copy selected items     |
-| `p`      | Paste items             |
-| `d`      | Delete selected items   |
-| `a`      | Create a new folder     |
-| `c`      | Rename a file or folder |
-| `?`      | Toggle this help screen |
+ | Key        | Action                          |
+ | ---------- | -------------------------       |
+ | `h`        | Go to parent folder             |
+ | `l`        | Go into folder                  |
+ | `j`        | Move down the list              |
+ | `k`        | Move up the list                |
+ | `Enter`    | Open file/folder                |
+ | `Space`    | Select / unselect files/folders |
+ | `x`        | Cut selected items              |
+ | `y`        | Copy selected items             |
+ | `p`        | Paste items                     |
+ | `d`        | Delete selected items           |
+ | `a`        | Create a new folder             |
+ | `c`        | Rename a file or folder         |
+ | `r`        | Refresh directory               |
+ | `?`        | Toggle this help screen         |
 
 ## Installation
 
@@ -70,4 +71,3 @@ Contributions are welcome! Feel free to open issues or submit pull requests.
 ## License
 
 MIT License © Mahadevan K
-

--- a/doc/vimnc.txt
+++ b/doc/vimnc.txt
@@ -29,6 +29,7 @@ The following keys are used within VimNC:
   d                  Delete selected items
   a                  Create a new folder
   c                  Rename a file or folder
+  r                  Refresh directory
   ?                  Toggle this help screen
 
 ==============================================================================
@@ -38,7 +39,7 @@ You can install this plugin using your favorite plugin manager.
 
 Using vim-plug:
 
-    Plug 'yourusername/vim-file-manager'
+    Plug 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -46,7 +47,7 @@ Then run:
 
 Using Vundle:
 
-    Plugin 'yourusername/vim-file-manager'
+    Plugin 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -66,7 +67,7 @@ To make opening VimNC even quicker, you can map the command to a convenient
 key combination. For example, to map it to <Leader>f, add the following to
 your .vimrc or init.vim:
 
-> 
+>
     " Map <leader>f to open VimNC file manager
     nnoremap <leader>f :VimNC<CR>
 <
@@ -84,4 +85,3 @@ MIT License © Mahadevan K
 ==============================================================================
 
 vim:tw=78:ts=8:ft=help:norl:
-


### PR DESCRIPTION
- Fix Windows path handling by consistently using backslashes
  - Update join_path() to convert all slashes to backslashes
  - Change directory marker from '/' to '\'
  - Ensure proper path formatting in all operations

- Fix directory navigation issues
  - Improve parent directory calculation using string manipulation
  - Fix navigation on '^ ..' line
  - Make h, l and Enter key navigation behavior consistent

- Optimize user experience
  - Remove redundant echo messages during navigation
  - Keep all navigation operations silent
  - Maintain code simplicity and readability

This commit fixes issues with directory navigation on Windows systems and ensures consistent behavior across all navigation methods.