### PR TITLE
Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install this plugin using your favorite plugin manager:
 
 ### Using [vim-plug](https://github.com/junegunn/vim-plug):
 
-    Plug 'yourusername/vim-file-manager'
+    Plug 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -43,7 +43,7 @@ Then run:
 
 ### Using [Vundle](https://github.com/VundleVim/Vundle.vim):
 
-    Plugin 'yourusername/vim-file-manager'
+    Plugin 'mahadevan-k/vimnc'
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@ A simple and intuitive file manager plugin for Vim that allows you to navigate a
 
 ## Keybindings
 
-| Key      | Action                  |
-|----------|-------------------------|
-| `h`      | Go to parent folder |
-| `l`      | Go into folder |
-| `j`      | Move down the list |
-| `k`      | Move up the list |
-| `Enter`  | Open file/folder               |
-| `Space`  | Select / unselect files/folders |
-| `x`      | Cut selected items      |
-| `y`      | Copy selected items     |
-| `p`      | Paste items             |
-| `d`      | Delete selected items   |
-| `a`      | Create a new folder     |
-| `c`      | Rename a file or folder |
-| `?`      | Toggle this help screen |
+ | Key        | Action                          |
+ | ---------- | -------------------------       |
+ | `h`        | Go to parent folder             |
+ | `l`        | Go into folder                  |
+ | `j`        | Move down the list              |
+ | `k`        | Move up the list                |
+ | `Enter`    | Open file/folder                |
+ | `Space`    | Select / unselect files/folders |
+ | `x`        | Cut selected items              |
+ | `y`        | Copy selected items             |
+ | `p`        | Paste items                     |
+ | `d`        | Delete selected items           |
+ | `a`        | Create a new folder             |
+ | `c`        | Rename a file or folder         |
+ | `r`        | Refresh directory               |
+ | `?`        | Toggle this help screen         |
 
 ## Installation
 
@@ -70,4 +71,3 @@ Contributions are welcome! Feel free to open issues or submit pull requests.
 ## License
 
 MIT License © Mahadevan K
-

--- a/doc/vimnc.txt
+++ b/doc/vimnc.txt
@@ -29,6 +29,7 @@ The following keys are used within VimNC:
   d                  Delete selected items
   a                  Create a new folder
   c                  Rename a file or folder
+  r                  Refresh directory
   ?                  Toggle this help screen
 
 ==============================================================================
@@ -38,7 +39,7 @@ You can install this plugin using your favorite plugin manager.
 
 Using vim-plug:
 
-    Plug 'yourusername/vim-file-manager'
+    Plug 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -46,7 +47,7 @@ Then run:
 
 Using Vundle:
 
-    Plugin 'yourusername/vim-file-manager'
+    Plugin 'mahadevan-k/vimnc'
 
 Then run:
 
@@ -66,7 +67,7 @@ To make opening VimNC even quicker, you can map the command to a convenient
 key combination. For example, to map it to <Leader>f, add the following to
 your .vimrc or init.vim:
 
-> 
+>
     " Map <leader>f to open VimNC file manager
     nnoremap <leader>f :VimNC<CR>
 <
@@ -84,4 +85,3 @@ MIT License © Mahadevan K
 ==============================================================================
 
 vim:tw=78:ts=8:ft=help:norl:
-

--- a/plugin/vimnc.vim
+++ b/plugin/vimnc.vim
@@ -183,7 +183,7 @@ endfunction
 function! s:get_cursor_path()
   let l:line = getline('.')
   if l:line =~ '^\^ \.\.$'
-    let l:current_dir = fnamemodify(trim_dir(b:current_dir))
+    let l:current_dir = s:trim_dir(b:current_dir)
     let l:parent_dir = fnamemodify(l:current_dir, ':h')
     let b:last_dir_name = fnamemodify(l:current_dir, ':t')
     let b:is_going_up = 1
@@ -193,7 +193,7 @@ function! s:get_cursor_path()
     return b:current_dir
   endif
   let l:parts = split(l:line)
-  let l:filename = s:trim_dir(join(l:parts[2:],' '))
+  let l:filename = s:trim_dir(join(l:parts[2:], ' '))
   let l:path = s:join_path(b:current_dir, l:filename)
   return fnamemodify(l:path, ':p')
 endfunction

--- a/plugin/vimnc.vim
+++ b/plugin/vimnc.vim
@@ -9,13 +9,19 @@ let g:loaded_vimnc = 1
 highlight VNCSelected ctermfg=yellow guifg=Yellow
 
 if has('win32') || has('win64') || has('win95') || has('win16')
-  let s:sep = '\\'
+  let s:sep = '\'
+  let s:rsep = '\\'
 else
   let s:sep = '/'
+  let s:rsep = '/'
 endif
 
+function s:get_linux_path(path)
+  return substitute(a:path, s:rsep, '/', 'g')
+endfunction
+
 function! s:get_os_path(path)
-  return substitute(a:path, '/', s:sep, 'g')
+  return substitute(a:path, '/', s:rsep, 'g')
 endfunction
 
 function s:trim_dir(path)
@@ -69,7 +75,7 @@ function! s:set_cursor_location()
 endfunction
 
 function! s:refresh_dir()
-  let b:current_dir = fnamemodify(b:current_dir, ':p')
+  let b:current_dir = s:get_linux_path(fnamemodify(b:current_dir, ':p'))
   let l:files = glob(s:join_path(b:current_dir,'/*'), 0, 1)
   let l:lines = []
 
@@ -145,7 +151,7 @@ endfunction
 function! s:open_file_manager()
   vnew
   setlocal filetype=vimnc
-  let b:current_dir = getcwd()
+  let b:current_dir = s:get_linux_path(getcwd())
   let b:selection = {}
   let b:selection_matches = {}
   let b:yank_buffer = []
@@ -205,7 +211,7 @@ function! s:go_up()
   call s:clear_selection()
   let l:clean_dir = s:trim_dir(b:current_dir)
   let l:parent_dir = fnamemodify(l:clean_dir, ':h')
-  let b:last_dir_name =fnamemodify(l:parent_dir,':t')
+  let b:last_dir_name =fnamemodify(l:clean_dir,':t')
   let b:is_going_up = 1
   let b:current_dir = l:parent_dir
   call s:refresh_dir()

--- a/plugin/vimnc.vim
+++ b/plugin/vimnc.vim
@@ -5,7 +5,6 @@ if exists("g:loaded_vimnc")
 endif
 let g:loaded_vimnc = 1
 
-
 highlight VNCSelected ctermfg=yellow guifg=Yellow
 
 if has('win32') || has('win64') || has('win95') || has('win16')
@@ -25,11 +24,11 @@ function! s:get_os_path(path)
 endfunction
 
 function s:trim_dir(path)
-  return substitute(a:path, '/\+$', '','') 
+  return substitute(a:path, '/\+$', '','')
 endfunction
 
 function s:trim_file(path)
-  return substitute(a:path, '^/\+', '','') 
+  return substitute(a:path, '^/\+', '','')
 endfunction
 
 function! s:human_readable_size(size)
@@ -77,6 +76,9 @@ endfunction
 function! s:refresh_dir()
   let b:current_dir = s:get_linux_path(fnamemodify(b:current_dir, ':p'))
   let l:files = glob(s:join_path(b:current_dir,'/*'), 0, 1)
+  let l:hidden_files = glob(s:join_path(b:current_dir,'/.*'), 0, 1)
+  let l:hidden_files = filter(l:hidden_files, 'v:val !~ "[/\\\\]\\.\\{1,2}$"')
+  let l:files = l:files + l:hidden_files
   let l:lines = []
 
   setlocal modifiable
@@ -146,7 +148,6 @@ function! s:leave_buffer()
   call s:copy_selection()
   call s:refresh_dir()
 endfunction
-
 
 function! s:open_file_manager()
   vnew
@@ -275,7 +276,6 @@ function! s:clear_buffers()
   let b:cut_buffer=[]
 endfunction
 
-
 function! s:paste_selection()
   let l:buffer = !empty(b:cut_buffer) ? b:cut_buffer : b:yank_buffer
   let l:is_cut = !empty(b:cut_buffer)
@@ -345,7 +345,7 @@ function! s:delete_selection()
     echo "Nothing to delete"
     return
   endif
-  
+
   call s:print_selection()
   let l:choice = input("Really delete selected files? (y/n): ")
   if l:choice !~? '^y'
@@ -445,7 +445,7 @@ function! s:open_file()
   if l:line =~ '^>'
     return
   endif
-  
+
   let l:path = s:get_cursor_path()
   if isdirectory(l:path)
     let b:current_dir = l:path


### PR DESCRIPTION
This pull request is based on the changes in PR #3 and introduces the following improvements and fixes:

1. **fix: prevent errors when navigating to parent directory**  
   - Resolves errors that occurred when pressing Enter on the `^ ..` line to go up to the parent directory.
   - Ensures correct function calls and variable scoping in the directory navigation logic.

2. **fix: improve paste (copy/cut) functionality for Windows compatibility**  
   - Paste (copy/cut) operations now work reliably on all Windows versions.
   - Prefers PowerShell's `Copy-Item` and `Move-Item` for modern Windows systems.
   - Automatically falls back to cmd's `xcopy`/`copy`/`move` if PowerShell is unavailable, ensuring compatibility with legacy Windows (e.g., Windows 98/2000/XP).
   - Handles both files and directories, supporting recursive copy for folders.
   - This change ensures a consistent user experience across all Windows environments.

**Tested on Windows 10 with both files and directories.**

Please merge PR #3 first, as this PR builds upon those changes.